### PR TITLE
EIP-2681 compliance - fail CREATE/CREATE2 at nonce max uint64-1

### DIFF
--- a/core/vm/create_test.go
+++ b/core/vm/create_test.go
@@ -1,0 +1,95 @@
+package vm_test
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// Minimal block context with transfer hooks
+func blockCtx() vm.BlockContext {
+	return vm.BlockContext{
+		CanTransfer: func(db vm.StateDB, addr common.Address, amount *big.Int) bool {
+			return db.GetBalance(addr).Cmp(amount) >= 0
+		},
+		Transfer: func(db vm.StateDB, from, to common.Address, amount *big.Int) {
+			db.SubBalance(from, amount)
+			db.AddBalance(to, amount)
+		},
+		GetHash:     func(uint64) common.Hash { return common.Hash{} },
+		Coinbase:    common.Address{},
+		GasLimit:    30_000_000,
+		BlockNumber: big.NewInt(1),
+		BaseFee:     big.NewInt(0),
+		Time:        big.NewInt(1),
+	}
+}
+
+func TestCreate_TopLevel_MaxNonce(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db), nil)
+
+	caller := common.HexToAddress("0xCA11ER")
+	statedb.AddBalance(caller, big.NewInt(1e18))
+	statedb.SetNonce(caller, math.MaxUint64)
+
+	evm := vm.NewEVM(blockCtx(), vm.TxContext{Origin: caller}, statedb, params.AllEthashProtocolChanges, vm.Config{})
+
+	gas := uint64(1_000_000)
+	ret, addr, left, err := evm.Create(vm.AccountRef(caller), []byte{0x00}, gas, big.NewInt(0))
+	require.Error(t, err)
+	require.Equal(t, vm.ErrNonceMax, err) // explicit EIP-2681 error
+	require.Nil(t, ret)
+	require.Equal(t, gas, left)                                        // full child gas returned
+	require.Equal(t, uint64(math.MaxUint64), statedb.GetNonce(caller)) // no increment
+	require.Len(t, statedb.GetCode(addr), 0)                           // nothing deployed
+}
+
+func TestCreate_Internal_MaxNonce(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db), nil)
+
+	creator := common.HexToAddress("0xC0DECAFE")
+	statedb.AddBalance(creator, big.NewInt(1e18))
+	statedb.CreateAccount(creator)
+	statedb.SetNonce(creator, math.MaxUint64)
+	// runtime: PUSH1 0 (size) PUSH1 0 (offset) PUSH1 0 (value) CREATE STOP
+	code := []byte{0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xF0, 0x00}
+	statedb.SetCode(creator, code)
+
+	evm := vm.NewEVM(blockCtx(), vm.TxContext{Origin: creator}, statedb, params.AllEthashProtocolChanges, vm.Config{})
+
+	gas := uint64(200_000)
+	// Call into the creator's code; internal CREATE should fail and not run initcode.
+	_, _, err := evm.Call(vm.AccountRef(creator), creator, nil, gas, big.NewInt(0))
+	require.NoError(t, err)                                             // external CALL ok; internal CREATE failed
+	require.Equal(t, uint64(math.MaxUint64), statedb.GetNonce(creator)) // unchanged
+	require.Equal(t, code, statedb.GetCode(creator))                    // no new code created
+}
+
+func TestCreate_Boundary_SucceedsAtMaxMinus1(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db), nil)
+
+	caller := common.HexToAddress("0xB0UNDARY")
+	statedb.AddBalance(caller, big.NewInt(1e18))
+	statedb.SetNonce(caller, math.MaxUint64-1)
+
+	evm := vm.NewEVM(blockCtx(), vm.TxContext{Origin: caller}, statedb, params.AllEthashProtocolChanges, vm.Config{})
+
+	gas := uint64(1_000_000)
+	ret, addr, left, err := evm.Create(vm.AccountRef(caller), []byte{0x00}, gas, big.NewInt(0))
+	require.NoError(t, err)
+	require.NotNil(t, ret)                                             // creation ran
+	require.Less(t, left, gas)                                         // some gas consumed
+	require.Equal(t, uint64(math.MaxUint64), statedb.GetNonce(caller)) // incremented to max
+	_ = addr
+}

--- a/core/vm/create_test.go
+++ b/core/vm/create_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// Minimal block context with transfer hooks
 func blockCtx() vm.BlockContext {
 	return vm.BlockContext{
 		CanTransfer: func(db vm.StateDB, addr common.Address, amount *big.Int) bool {
@@ -29,7 +28,7 @@ func blockCtx() vm.BlockContext {
 		GasLimit:    30_000_000,
 		BlockNumber: big.NewInt(1),
 		BaseFee:     big.NewInt(0),
-		Time:        big.NewInt(1),
+		Time:        big.NewInt(1), // your fork uses *big.Int here
 	}
 }
 
@@ -41,12 +40,12 @@ func TestCreate_TopLevel_MaxNonce(t *testing.T) {
 	statedb.AddBalance(caller, big.NewInt(1e18))
 	statedb.SetNonce(caller, math.MaxUint64)
 
-	evm := vm.NewEVM(blockCtx(), vm.TxContext{Origin: caller}, statedb, params.AllEthashProtocolChanges, vm.Config{})
+	e := vm.NewEVM(blockCtx(), vm.TxContext{Origin: caller}, statedb, params.AllEthashProtocolChanges, vm.Config{})
 
 	gas := uint64(1_000_000)
-	ret, addr, left, err := evm.Create(vm.AccountRef(caller), []byte{0x00}, gas, big.NewInt(0))
+	ret, addr, left, err := e.Create(vm.AccountRef(caller), []byte{0x00}, gas, big.NewInt(0))
 	require.Error(t, err)
-	require.Equal(t, vm.ErrNonceMax, err) // explicit EIP-2681 error
+	require.Equal(t, vm.ErrNonceMax, err)
 	require.Nil(t, ret)
 	require.Equal(t, gas, left)                                        // full child gas returned
 	require.Equal(t, uint64(math.MaxUint64), statedb.GetNonce(caller)) // no increment
@@ -61,18 +60,18 @@ func TestCreate_Internal_MaxNonce(t *testing.T) {
 	statedb.AddBalance(creator, big.NewInt(1e18))
 	statedb.CreateAccount(creator)
 	statedb.SetNonce(creator, math.MaxUint64)
+
 	// runtime: PUSH1 0 (size) PUSH1 0 (offset) PUSH1 0 (value) CREATE STOP
 	code := []byte{0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xF0, 0x00}
 	statedb.SetCode(creator, code)
 
-	evm := vm.NewEVM(blockCtx(), vm.TxContext{Origin: creator}, statedb, params.AllEthashProtocolChanges, vm.Config{})
+	e := vm.NewEVM(blockCtx(), vm.TxContext{Origin: creator}, statedb, params.AllEthashProtocolChanges, vm.Config{})
 
 	gas := uint64(200_000)
-	// Call into the creator's code; internal CREATE should fail and not run initcode.
-	_, _, err := evm.Call(vm.AccountRef(creator), creator, nil, gas, big.NewInt(0))
-	require.NoError(t, err)                                             // external CALL ok; internal CREATE failed
-	require.Equal(t, uint64(math.MaxUint64), statedb.GetNonce(creator)) // unchanged
-	require.Equal(t, code, statedb.GetCode(creator))                    // no new code created
+	_, _, err := e.Call(vm.AccountRef(creator), creator, nil, gas, big.NewInt(0)) // (ret, left, err)
+	require.NoError(t, err)                                                       // CALL succeeded; internal CREATE failed with 0 result
+	require.Equal(t, uint64(math.MaxUint64), statedb.GetNonce(creator))
+	require.Equal(t, code, statedb.GetCode(creator))
 }
 
 func TestCreate_Boundary_SucceedsAtMaxMinus1(t *testing.T) {
@@ -83,13 +82,26 @@ func TestCreate_Boundary_SucceedsAtMaxMinus1(t *testing.T) {
 	statedb.AddBalance(caller, big.NewInt(1e18))
 	statedb.SetNonce(caller, math.MaxUint64-1)
 
-	evm := vm.NewEVM(blockCtx(), vm.TxContext{Origin: caller}, statedb, params.AllEthashProtocolChanges, vm.Config{})
+	e := vm.NewEVM(blockCtx(), vm.TxContext{Origin: caller}, statedb, params.AllEthashProtocolChanges, vm.Config{})
 
 	gas := uint64(1_000_000)
-	ret, addr, left, err := evm.Create(vm.AccountRef(caller), []byte{0x00}, gas, big.NewInt(0))
+
+	// Initcode that returns 1 byte of runtime code (0x00):
+	// PUSH1 0x00 ; PUSH1 0x00 ; MSTORE ; PUSH1 0x01 ; PUSH1 0x00 ; RETURN
+	initcode := []byte{0x60, 0x00, 0x60, 0x00, 0x52, 0x60, 0x01, 0x60, 0x00, 0xF3}
+
+	ret, addr, left, err := e.Create(vm.AccountRef(caller), initcode, gas, big.NewInt(0))
 	require.NoError(t, err)
-	require.NotNil(t, ret)                                             // creation ran
-	require.Less(t, left, gas)                                         // some gas consumed
-	require.Equal(t, uint64(math.MaxUint64), statedb.GetNonce(caller)) // incremented to max
-	_ = addr
+
+	// Some gas must be consumed by initcode + code deposit
+	require.Less(t, left, gas)
+
+	// Nonce incremented to MaxUint64
+	require.Equal(t, uint64(math.MaxUint64), statedb.GetNonce(caller))
+
+	// Deployed runtime code length is exactly 1 byte
+	require.Len(t, statedb.GetCode(addr), 1)
+
+	// (Optional) ret is the runtime code returned by constructor; should also be 1 byte
+	require.Len(t, ret, 1)
 }

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -36,6 +36,9 @@ var (
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
 	ErrNonceUintOverflow        = errors.New("nonce uint64 overflow")
+	// EIP-2681: attempt to CREATE/CREATE2 when creator nonce == 2^64-1.
+	// Handled in EVM.create; opcode handlers will observe a non-nil suberr and push 0.
+	ErrNonceMax = errors.New("create on account with max nonce violates EIP-2681")
 
 	// errStopToken is an internal token indicating interpreter loop termination,
 	// never returned to outside callers.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -17,6 +17,7 @@
 package vm
 
 import (
+	"math"
 	"math/big"
 	"sync/atomic"
 
@@ -411,6 +412,11 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		return nil, common.Address{}, gas, ErrInsufficientBalance
 	}
 	nonce := evm.StateDB.GetNonce(caller.Address())
+	// EIP-2681: creator nonce == 2^64-1 → creation fails; no initcode gas is charged.
+	if nonce == math.MaxUint64 {
+		return nil, common.Address{}, gas, ErrNonceMax
+	}
+	// Generic overflow guard (kept for completeness).
 	if nonce+1 < nonce {
 		return nil, common.Address{}, gas, ErrNonceUintOverflow
 	}


### PR DESCRIPTION
## Changes
* Add guard in `core/vm/evm.go:create` - if creator nonce == `math.MaxUint64` ⇒ return `(nil, addr{}, gas, ErrNonceMax)` before any side effects.
* `core/vm/errors.go`: add `ErrNonceMax`. No opcode changes needed (errors already push 0).
* Tests: top-level and internal create fail at `2⁶⁴−1` (full child gas returned); boundary at 2⁶⁴−2 succeeds and increments.
* Addresses [Issue #400](https://github.com/cosmos/evm/issues/400)
*  [EIP-2681 referene](https://eips.ethereum.org/EIPS/eip-2681)

## Testing

```
# Top-level create must fail at nonce==2^64-1 (no initcode gas)
go test ./core/vm -run TestCreate_TopLevel_MaxNonce -v

# Internal CREATE must fail at nonce==2^64-1 (pushes 0; no side effects)
go test ./core/vm -run TestCreate_Internal_MaxNonce -v

# Boundary: nonce==2^64-2 succeeds, increments to 2^64-1
go test ./core/vm -run TestCreate_Boundary_SucceedsAtMaxMinus1 -v
```