### PR TITLE
fix(rpc): use ResettingTimer for RPC duration metrics

### DIFF
--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -31,7 +31,7 @@ var (
 	// serveTimeHistName is the prefix of the per-request serving time histograms.
 	serveTimeHistName = "rpc/duration"
 
-	rpcServingTimer = metrics.NewRegisteredTimer("rpc/duration/all", nil)
+	rpcServingTimer = metrics.NewRegisteredResettingTimer("rpc/duration/all", nil)
 )
 
 // updateServeTimeHistogram tracks the serving time of a remote RPC call.


### PR DESCRIPTION
The rpc/duration/all metric was using metrics.NewRegisteredTimer which accumulates samples over the entire process lifetime. When exported to Prometheus, quantile values grow to millions of seconds (displayed as years).

Switch to NewRegisteredResettingTimer which resets its sample buffer on each Prometheus scrape, ensuring quantile calculations use recent data only.